### PR TITLE
Restrict experiments to a single custom environment

### DIFF
--- a/cmd/chaos-dashboard/main.go
+++ b/cmd/chaos-dashboard/main.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -171,6 +171,7 @@ func SelectPods(ctx context.Context, c client.Client, r client.Reader, selector 
 			}
 
 			pods = append(pods, podList.Items...)
+			podList.Items = nil
 		}
 	} else {
 		if err := listFunc(ctx, &podList, &listOptions); err != nil {


### PR DESCRIPTION
### What problem does this PR solve?
We want to restrict chaos experiments to custom env. only. We also want to only allow experiments to target single custom environment.

![image](https://user-images.githubusercontent.com/39484134/108387874-f2de7400-7205-11eb-9449-b4ec4c8442de.png)
![image](https://user-images.githubusercontent.com/39484134/108387929-012c9000-7206-11eb-9eaf-74e9a2fb58e5.png)

### Considerations
- any infrastructure/platform namespaces will be blacklisted via chaos-mesh configuration


### What is changed and how does it work?

### Checklist
<!-- Remove the items that are not applicable. -->

Tests
<!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] E2E test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Breaking backward compatibility

Related changes

- [ ] Need to update the documentation

### Does this PR introduce a user-facing change?
<!-- 
If no, just leave the release note block below as is.

If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
